### PR TITLE
fix: direct access to the /account path causes the browser to spin

### DIFF
--- a/src/mods/users/screens/account/Account.tsx
+++ b/src/mods/users/screens/account/Account.tsx
@@ -1,11 +1,15 @@
+import { GetServerSideProps } from 'next'
+import { getSession } from 'next-auth/react'
 import { useCallback, useLayoutEffect, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
+import { dehydrate } from 'react-query'
 
 import { useLoggedIn } from '@/mods/auth/hooks/useLoggedIn'
 import { useRefreshSecret } from '@/mods/auth/hooks/useRefreshSecret'
 import { Confirm } from '@/mods/shared/components/Confirm'
 import { Notifier } from '@/mods/shared/components/Notification'
 import { useTitle } from '@/mods/shared/hooks/useTitle'
+import { getQueryClient } from '@/mods/shared/libs/queryClient'
 import { Button, Input, Text, Title } from '@/ui'
 
 import { useEditUser } from '../../hooks/useEditUser'
@@ -173,6 +177,18 @@ export function Account() {
       />
     </>
   )
+}
+
+export const getServerSideProps: GetServerSideProps = async ({ req }) => {
+  const session = await getSession({ req })
+  const queryClient = getQueryClient()
+
+  return {
+    props: {
+      session,
+      dehydratedState: dehydrate(queryClient),
+    },
+  }
 }
 
 Account.isProtected = true

--- a/src/mods/users/screens/account/index.ts
+++ b/src/mods/users/screens/account/index.ts
@@ -1,1 +1,1 @@
-export { default } from './Account'
+export { default, getServerSideProps } from './Account'

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -1,1 +1,1 @@
-export { default } from '@/mods/users/screens/account'
+export { default, getServerSideProps } from '@/mods/users/screens/account'


### PR DESCRIPTION
Issue: https://github.com/fonoster/fonoster/issues/356